### PR TITLE
Fix MySQL connection fail

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -38,6 +38,7 @@
   mysql_user:
     login_user: "{{ xtradb_root_user }}"
     login_password: "{{ xtradb_root_password }}"
+    login_unix_socket: /var/run/mysqld/mysqld.sock
     user: "{{ xtradb_sst_user }}"
     password: "{{ xtradb_sst_password }}"
     priv: "*.*:grant,reload,lock tables,process,replication client"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,9 +35,10 @@
 - name: Install packages
   package:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items: "{{ xtradb_packages }}"
   tags: install
+
 
 - name: Ensure service is started
   service:

--- a/tasks/secure_install.yml
+++ b/tasks/secure_install.yml
@@ -30,6 +30,7 @@
     name: ""
     host_all: yes
     state: absent
+    login_unix_socket: /var/run/mysqld/mysqld.sock
 
 - name: "Secure the MySQL root user for localhost"
   mysql_user:
@@ -37,6 +38,7 @@
     login_password: "{{ xtradb_root_password }}"
     name: "{{ xtradb_root_user }}"
     host: "{{ item }}"
+    login_unix_socket: /var/run/mysqld/mysqld.sock
   with_items:
     - "::1"
     - "127.0.0.1"
@@ -50,6 +52,7 @@
     login_user: "{{ xtradb_root_user }}"
     login_password: "{{ xtradb_root_password }}"
     state: absent
+    login_unix_socket: /var/run/mysqld/mysqld.sock
 
 
 - name: Marking as secured


### PR DESCRIPTION
* fix mysql connection fail in ansible 2.7
```
"msg": "unable to connect to database, check login_user and login_password are correct or /root/.my.cnf has the credentials. Exception message: (1698, \"Access denied for user 'root'@'localhost'\")"}
``` 
more info  [1]
* renamed state ('installed' -> 'present') as it deprecated in coming ansible 2.9

[1] https://github.com/ansible/ansible/issues/47736